### PR TITLE
make the 'Last Modified' time setting optional

### DIFF
--- a/cheetah/Compiler.py
+++ b/cheetah/Compiler.py
@@ -1908,7 +1908,7 @@ class ModuleCompiler(SettingsManager, GenUtils):
         else:
             self.addModuleGlobal('__CHEETAH_src__ = None')
             if self.setting('addSrcModifiedToCompilerOutput'):
-				self.addModuleGlobal('__CHEETAH_srcLastModified__ = None')
+                self.addModuleGlobal('__CHEETAH_srcLastModified__ = None')
 
         moduleDef = """%(header)s
 %(docstring)s

--- a/cheetah/Compiler.py
+++ b/cheetah/Compiler.py
@@ -68,6 +68,7 @@ _DEFAULT_COMPILER_SETTINGS = [
     ('monitorSrcFile', False, ''),
     ('outputMethodsBeforeAttributes', True, ''),
     ('addTimestampsToCompilerOutput', True, ''),
+    ('addSrcModifiedToCompilerOutput', True, ''),
 
     ## Customizing the #extends directive
     ('autoImportForExtendsDirective', True, ''),
@@ -1190,8 +1191,8 @@ class ClassCompiler(GenUtils):
             self._generatedAttribs.append('_CHEETAH_genTimestamp = __CHEETAH_genTimestamp__')
 
         self._generatedAttribs.append('_CHEETAH_src = __CHEETAH_src__')
-        self._generatedAttribs.append(
-            '_CHEETAH_srcLastModified = __CHEETAH_srcLastModified__')
+        if self.setting('addSrcModifiedToCompilerOutput'):
+            self._generatedAttribs.append('_CHEETAH_srcLastModified = __CHEETAH_srcLastModified__')
 
         if self.setting('templateMetaclass'):
             self._generatedAttribs.append('__metaclass__ = '+self.setting('templateMetaclass'))
@@ -1902,10 +1903,12 @@ class ModuleCompiler(SettingsManager, GenUtils):
         if self._filePath:
             timestamp = self.timestamp(self._fileMtime)
             self.addModuleGlobal('__CHEETAH_src__ = %r'%self._filePath)
-            self.addModuleGlobal('__CHEETAH_srcLastModified__ = %r'%timestamp)
+            if self.setting('addSrcModifiedToCompilerOutput'):
+                self.addModuleGlobal('__CHEETAH_srcLastModified__ = %r'%timestamp)
         else:
             self.addModuleGlobal('__CHEETAH_src__ = None')
-            self.addModuleGlobal('__CHEETAH_srcLastModified__ = None')            
+            if self.setting('addSrcModifiedToCompilerOutput'):
+				self.addModuleGlobal('__CHEETAH_srcLastModified__ = None')
 
         moduleDef = """%(header)s
 %(docstring)s


### PR DESCRIPTION
Setting "Last Modified" on every file every time you run on it, even when nothing's changed, makes tools like "make" somewhat unhappy, and makes it hard to do things like rsync --link-dest. This patch (which we've been running for many years, and the original author of which is lost to the sands of time) makes writing that header optional.
