### PR TITLE
and/or is a bad ternary.

### DIFF
--- a/cheetah/Compiler.py
+++ b/cheetah/Compiler.py
@@ -1106,7 +1106,15 @@ class AutoMethodCompiler(MethodCompiler):
         else:
             empty = ''
 
-        self.addChunk('return _dummyTrans and trans.response().getvalue() or %r' % empty)
+        self.addChunk('if _dummyTrans:')
+        self.indent()
+        self.addChunk('self.transaction = None')
+        self.addChunk('return trans.response().getvalue()')
+        self.dedent()
+        self.addChunk('else:')
+        self.indent()
+        self.addChunk('return %r' % empty)
+        self.dedent()
 
     def addMethArg(self, name, defVal=None):
         self._argStringList.append( (name, defVal) )


### PR DESCRIPTION
With autoAssign... on, empty-string return values were being converted to Nones.

This DOES NOT affect normal Cheetah usage; it only causes problems when the compiler setting is turned on.
