### PR TITLE
rollback proofing

### DIFF
--- a/cheetah/Compiler.py
+++ b/cheetah/Compiler.py
@@ -1664,13 +1664,19 @@ class ModuleCompiler(SettingsManager, GenUtils):
             "import types",
             "from Cheetah.Version import MinCompatibleVersion as RequiredCheetahVersion",            
             "from Cheetah.Version import MinCompatibleVersionTuple as RequiredCheetahVersionTuple",
-            "from Cheetah.Template import Template, NO_CONTENT",
+            "from Cheetah.Template import Template",
             "from Cheetah.DummyTransaction import *",
             "from Cheetah.NameMapper import NotFound, valueForName, valueFromSearchList, valueFromFrameOrSearchList",
             "from Cheetah.CacheRegion import CacheRegion",
             "import Cheetah.Filters as Filters",
             "import Cheetah.ErrorCatchers as ErrorCatchers",
-            ]        
+            "",
+            "try:",
+            "    #Backward compatibility with 2.4.5",
+            "    from Cheetah.Template import NO_CONTENT",
+            "except ImportError:",
+            "    NO_CONTENT = None",
+        ]
 
         self._importedVarNames = ['sys',
                                   'os',

--- a/cheetah/Version.py
+++ b/cheetah/Version.py
@@ -1,5 +1,5 @@
-Version = '2.4.6'
-VersionTuple = (2, 4, 6, 'development', 0)
+Version = '2.4.7'
+VersionTuple = (2, 4, 7, 'development', 0)
 
 MinCompatibleVersion = '2.0rc6'
 MinCompatibleVersionTuple = (2, 0, 0, 'candidate', 6)


### PR DESCRIPTION
templates built with 2.4.7 will work fine with cheetah 2.4.5
