### PR TITLE
Remove unused Cheetah.Servlet.Servlet.request

### DIFF
--- a/cheetah/Servlet.py
+++ b/cheetah/Servlet.py
@@ -13,7 +13,6 @@ class Servlet(object):
 
     transaction = None
     application = None
-    request = None
     session = None
 
     def respond(self, trans=None):
@@ -25,8 +24,6 @@ definition.""")
     def sleep(self, transaction):
         super(Servlet, self).sleep(transaction)
         self.session = None
-        self.request  = None
-        self._request  = None
         self.response = None
         self.transaction = None
 

--- a/cheetah/Tests/Regressions.py
+++ b/cheetah/Tests/Regressions.py
@@ -132,9 +132,11 @@ class Mantis_Issue_11_Regression_Test(unittest.TestCase):
     '''
     def test_FailingBehavior(self):
         import cgi
+        # This used to break because Cheetah.Servlet.request used to be a class property that
+        # was None and came up earlier in VFSSL than the things in teh search list
         template = Cheetah.Template.Template("$escape($request)", searchList=[{'escape' : cgi.escape, 'request' : 'foobar'}])
         assert template
-        self.failUnlessRaises(AttributeError, template.respond)
+        assert template.respond()
 
     def test_FailingBehaviorWithSetting(self):
         import cgi

--- a/cheetah/Tests/Regressions.py
+++ b/cheetah/Tests/Regressions.py
@@ -130,10 +130,11 @@ class Mantis_Issue_11_Regression_Test(unittest.TestCase):
           File "/usr/lib64/python2.6/cgi.py", line 1035, in escape
             s = s.replace("&", "&") # Must be done first! 
     '''
-    def test_FailingBehavior(self):
+    def test_RequestInSearchList(self):
         import cgi
         # This used to break because Cheetah.Servlet.request used to be a class property that
-        # was None and came up earlier in VFSSL than the things in teh search list
+        # was None and came up earlier in VFSSL than the things in the search list.
+        # Currently, request is available when being passed through the search list.
         template = Cheetah.Template.Template("$escape($request)", searchList=[{'escape' : cgi.escape, 'request' : 'foobar'}])
         assert template
         assert template.respond()


### PR DESCRIPTION
This is unused except in `Cheetah.Template.Template.webInput` method.  Which somewhat clearly states (in some odd english) in its documentation: 

```
This only in a subclass that also inherits from Webware's Servlet or
HTTPServlet. Otherwise you'll get an AttributeError on 'self.request'.
```

I ran the tests and none of them were failing that weren't failing `master`

The motivation for this change is as follows:

We're attempting to add `$request` to the `searchList` as this is needed for ~90% of #webcore refactors.  However, the template instance itself is always first in the `searchList` (err well actually second, behind an empty dictionary.  Could potentially save a list operation and a dictionary operation for every searchlist lookup by removing this, but that's for another day) and since the template instance is always first it finds the class attribute `Cheetah.Servlet.Servlet.request` before it finds our `{'request': request}` in the `searchList`.  For now, we're probably going to do the following "hack / workaround":

``` python
def instantiate_cheetah_template(...):
    # Greatly simplified
    # Support our modified get_var_from_search_list which ignores the template instance
    search_list = [{'request': request}]

    instance = cheetah_template_cls(...)
    # Make this show up before the class attribute
    instance.request = request

    return instance
```
