### PR TITLE
Create non-conflicting template module names

### DIFF
--- a/cheetah/Template.py
+++ b/cheetah/Template.py
@@ -104,9 +104,8 @@ def hashDict(d):
 def _genUniqueModuleName(baseModuleName):
     """The calling code is responsible for concurrency locking.
     """
-    if baseModuleName not in sys.modules:
-        finalName = baseModuleName
-    else:
+    finalName = baseModuleName
+    while finalName in sys.modules:
         finalName = ('cheetah_%s_%s_%s'%(baseModuleName,
                                          str(time.time()).replace('.', '_'),
                                          str(randrange(10000, 99999))))


### PR DESCRIPTION
The genUniqueModuleName() implementation generated module name
conflicts when rendering many templates in quick succession.
The combination of poor time resolution of str(time.time()) due
to the default string representation and too small value range
for the random part resulted in this.

Added a simple retry in case of conflicts.

Fixes mysterious looking failures that look like this:

  File "cheetah_DynamicallyCompiledCheetahTemplate_1336479589_95_84044.py", line 58, in **init**
  TypeError: super() argument 1 must be type, not None
